### PR TITLE
Bootstrap Travis CI Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ local_settings.py
 email_settings.py
 twitter_settings*
 .idea/
+
+*~
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  "2.7"
+install:
+  "pip install --use-wheel -r src/config/requirements.txt"
+script:
+  "python src/manage.py test -v3"
+env:
+ - DJANGO_SETTINGS_MODULE=travis_settings PYTHONPATH=src
+addons:
+  postgresql: 9.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 > Visit our homepage at [http://avasecure.com](http://avasecure.com)
 
 ### We build secure people
+
+[![Build Status](https://travis-ci.org/SafeStack/ava.svg?branch=master)](https://travis-ci.org/tveastman/ava)
+
 Information security is often misunderstood. Most people believe that if you throw enough gadgets at an organisation you will mitigate any potential vulnerability. Technology is only a fraction of the picture.
 Information security is at its heart a human problem. Wherever there exists choice, there is risk. 
 

--- a/src/apps/ava_core/tests.py
+++ b/src/apps/ava_core/tests.py
@@ -1,9 +1,7 @@
 from django.test import TestCase
 
-from ava_core.models import *
 
-class TargetMethodTests(TestCase):
-
-    def test_was_created_at_with_future_item(self):
-        #future_item = TargetPerson(created_at=timezone.now() + datetime.timedelta(days=30))
-        self.assertEqual(False, False)
+class SimpleTests(TestCase):
+    def test_pass(self):
+        """This test will always pass, unless the boostrapping is broken."""
+        self.assertTrue(True)

--- a/src/travis_settings.py
+++ b/src/travis_settings.py
@@ -1,0 +1,23 @@
+"""
+This settings file is used during Travis CI runs.
+"""
+
+from settings import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'ava',
+        'USER': 'postgres',
+    }
+}
+
+
+## HAYSTACK SETTINGS
+## (copied from local_settings)
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'PATH': os.path.join(os.path.dirname(__file__), 'whoosh_index'),
+    },
+}


### PR DESCRIPTION
This pull request configures ava for Travis CI integration. 

 - a Travis CI configuration file
 - a Django settings module for use during CI runs.
 - replace the broken test with a single always-passing test to confirm database initialisation
