### PR TITLE
Dockerizing AVA

### DIFF
--- a/INSTALL_Docker.md
+++ b/INSTALL_Docker.md
@@ -14,39 +14,11 @@ For those not familiar with Docker, it is an open-source project that automates 
 
 ---
 
-### Install AVA
+### Install and run AVA
 
 1. Pull down the latest version of the project `git clone git@github.com:SafeStack/ava.git`
 2. `cd ava`
-3. Get Compose to build the AVA image including the dependancies and requirements `docker-compose build`
-4. Create file for your local settings from template `cp local_settings.py.example local_settings.py`
-5. Using your prefered editor, edit `local_settings.py` changing the database and redis server settings. See below for further details.
-6. Create migrations for the database schema with `docker-compose run --rm web python src/manage.py makemigrations`
-7. Run migrations to create tables `docker-compose run --rm web python src/manage.py migrate`
-8. Create our first user `docker-compose run --rm web python src/manage.py createsuperuser`
-9. Run AVA! `docker-compose up -d`
-10. To view AVA in a browser, identify the IP of your docker instance `docker ip` and visit `http://<ip address>:8000` in your web browser.
+3. Use docker-compose to build the AVA application images and its dependencies and boot the app `docker-compose up`
+4. Once the app is running, in a second terminal, create our first user `docker-compose run --rm web python src/manage.py createsuperuser`
+5. Browse to http://localhost:8000 to access the AVA web frontend.
 
-### Local_Settings.py changes
-
-The Docker configuration we are now using to run AVA is made up of three different containers, AVA itself (derived from a container image with Python preinstalled), a Redis container and a PostgreSQL container. Because all these containers are separate, AVA is no longer talking to a Redis instance via Unix sockets and is also no longer talking to PostgreSQL on localhost. Fortunately Docker takes care of the networking and host name resolution for us, but we need to configure the local_settings.py to use network connectivity using the names specified in the fig.yml file, for example:
-```python
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'postgres',
-        'USER': 'postgres',
-        'PASSWORD': 'changeme',
-        'HOST': 'db',
-        'PORT': '5432',
-    }
-}
-```  
-and for Redis  
-```python
-# Redis socket location
-#SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH = '/var/run/redis/redis.sock'
-# Or use TCP
-SESSION_REDIS_HOST = 'redis'
-SESSION_REDIS_PORT = 6379
-```

--- a/bin/run-devserver.sh
+++ b/bin/run-devserver.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+## This script is used as the 'entry point' for the application
+## server docker container. It runs 'migrate' on every start to
+## ensure the database is built, and then executes the internal
+## Django devserver.
+
+## This is convenient for development, but it is *not* appropriate
+## to run the Django devserver on a deployed or production systems.
+## A TODO is to either configure this script to run in a non-debug
+## "production" mode, or a separate script.
+
+DIRECTORY=$(dirname $0)/..
+PYTHON=python
+MANAGE=${DIRECTORY}/src/manage.py
+
+## This one-off try-again is there because the postgres docker image
+## takes a few extra seconds to initialize the database cluster on
+## its first boot.
+##
+## It's not a loop because if it fails the second time there's probably
+## something else going wrong.
+
+${MANAGE} migrate --noinput
+RESULT=$?
+if [ ${RESULT} != 0 ]
+then
+    echo "Migrate failed, trying again in five seconds."
+    sleep 5
+    ${MANAGE} migrate --noinput
+fi
+
+${MANAGE} runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,16 @@
 db:
   image: postgres:9.3
   environment:
-    - POSTGRES_USER=postgres
-    - POSTGRES_PASSWORD=changeme
+    ## This password is obviously committed to version control. It would be
+    ## ill-advised to use it on any accessible deployment (seriously).
+    - POSTGRES_PASSWORD=T7mKAQOhMmo6hv0zOmm7
 redis:
   image: redis:2.8
 elasticsearch:
   image: elasticsearch
 web:
   build: .
-  command: python src/manage.py runserver 0.0.0.0:8000
+  command: bin/run-devserver.sh
   volumes:
     - .:/code
   ports:

--- a/src/local_settings.py.example
+++ b/src/local_settings.py.example
@@ -2,33 +2,6 @@
 ## TODO: Remove this file. It's not used in a docker-only AVA system
 ##       (which is the direction we're headed)
 
-import os
-
-# DATABASE SETTINGS
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'avadata',
-        'USER': 'avasecure',
-        'PASSWORD': 'changeme',
-        'HOST': '127.0.0.1',
-        'PORT': '5432',
-    }
-}
-
-
-# REDIS SETTINGS
-
-# Redis socket location
-SESSION_REDIS_UNIX_DOMAIN_SOCKET_PATH = '/var/run/redis/redis.sock'
-# Or use TCP
-#SESSION_REDIS_HOST = 'localhost'
-#SESSION_REDIS_PORT = 6379
-
-
-# HAYSTACK SETTINGS
-
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
@@ -36,7 +9,6 @@ HAYSTACK_CONNECTIONS = {
         'INDEX_NAME': 'haystack',
     },
 }
-
 
 # MANDRILL SETTINGS
 

--- a/src/local_settings.py.example
+++ b/src/local_settings.py.example
@@ -1,3 +1,7 @@
+
+## TODO: Remove this file. It's not used in a docker-only AVA system
+##       (which is the direction we're headed)
+
 import os
 
 # DATABASE SETTINGS

--- a/src/settings.py
+++ b/src/settings.py
@@ -20,12 +20,12 @@ TEMPLATE_DEBUG = True
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': '',                      # Or path to database file if using sqlite3.
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.environ.get('DB_ENV_DB', 'postgres'),
+        'USER': os.environ.get('DB_ENV_POSTGRES_USER', 'postgres'),
+        'PASSWORD': os.environ.get('DB_ENV_POSTGRES_PASSWORD', ''),
+        'HOST': os.environ.get('DB_PORT_5432_TCP_ADDR', ''),
+        'PORT': os.environ.get('DB_PORT_5432_TCP_PORT', ''),
     }
 }
 
@@ -142,8 +142,18 @@ SHORTEN_MODELS = {
     'T': 'ava_test_twitter.TwitterTest',
 }
 
+## REDIS CONFIGURATION
 
-SESSION_ENGINE = 'redis_sessions.session'
+
+USE_REDIS_CACHE = False  # Turned off for the moment -- not needed.
+if USE_REDIS_CACHE:
+    SESSION_ENGINE = 'redis_sessions.session'
+    SESSION_REDIS_HOST = os.environ.get('REDIS_PORT_6379_TCP_ADDR', None)
+    SESSION_REDIS_PORT = os.environ.get('REDIS_PORT_6379_TCP_PORT', None)
+    SESSION_REDIS_DB = 1
+    SESSION_REDIS_PREFIX = 'session'
+
+
 
 LOGIN_REDIRECT_URL= "/"
 
@@ -166,3 +176,12 @@ try:
     from email_settings import *
 except ImportError:
     pass
+
+
+## HAYSTACK CONFIGURATION
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'PATH': os.path.join(os.path.dirname(__file__), 'whoosh_index'),
+    },
+}

--- a/src/settings.py
+++ b/src/settings.py
@@ -185,3 +185,20 @@ HAYSTACK_CONNECTIONS = {
         'PATH': os.path.join(os.path.dirname(__file__), 'whoosh_index'),
     },
 }
+
+
+## (below commented out from local_settings.py)
+
+## MANDRILL SETTINGS
+
+#MANDRILL_API_KEY = "changeme"
+#EMAIL_BACKEND = "djrill.mail.backends.djrill.DjrillBackend"
+
+
+## CELERY CONFIGURATION
+
+#BROKER_URL = 'amqp://avasecure:changeme@localhost:5672/avatasks'
+#CELERY_ACCEPT_CONTENT = ['json']
+#CELERY_TASK_SERIALIZER = 'json'
+#CELERY_RESULT_SERIALIZER = 'json'
+


### PR DESCRIPTION
Make AVA run out-of-the-box using Docker compose with no additional
configuration. There will be a few more steps to this, including
cleaning out old settings files and configuring celery.