### PR TITLE
Migrate AVA to Python 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ twitter_settings*
 
 *~
 
+## Many .bak files were created during the 2to3 run
+*.bak

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  "2.7"
+  "3.4"
 install:
   ## This convoluted pip command builds all our dependencies so that Travis can cache them, greatly speeding up test runs.
   - "pip wheel --use-wheel -w ${HOME}/.cache/wheelhouse -f file://${HOME}/.cache/wheelhouse -r src/config/requirements.txt"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:2.7
+FROM python:3.4
 ENV PYTHONUNBUFFERED 1
-RUN apt-get update -qq && apt-get install -y build-essential python-dev libpqxx-4.0 libpqxx-dev libldap2-dev libsasl2-dev libssl-dev
+RUN apt-get update -qq && apt-get install -y build-essential python3-dev libpqxx-4.0 libpqxx-dev libldap2-dev libsasl2-dev libssl-dev
 RUN mkdir /code
 WORKDIR /code
 ADD ./src/config/requirements.txt /code/

--- a/src/apps/ava_core/__init__.py
+++ b/src/apps/ava_core/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 # Ensure that Celery is initialised when the module is loaded.
 from apps.ava_core.celery import task_manager

--- a/src/apps/ava_core/celery.py
+++ b/src/apps/ava_core/celery.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import os
 from celery import Celery

--- a/src/apps/ava_core/models.py
+++ b/src/apps/ava_core/models.py
@@ -21,7 +21,7 @@ class ReferenceModel(TimeStampedModel):
     description = models.TextField(max_length=500, verbose_name='Description')
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
     class Meta:
         abstract = True

--- a/src/apps/ava_core_auth/forms.py
+++ b/src/apps/ava_core_auth/forms.py
@@ -2,7 +2,7 @@ from django.forms import ModelForm
 from django.contrib.auth.models import User
 from apps.ava_core_auth.models import Team, UserRights
 from django.forms import fields, widgets
-from __builtin__ import False
+#from builtins import False
 
 
 class UserForm(ModelForm):
@@ -48,7 +48,7 @@ class UserCreateForm(UserForm):
     def clean(self):
         cleaned_data = super(UserCreateForm, self).clean()
         if cleaned_data.get('password') != cleaned_data.get('password2'):
-            self.add_error('password2', u'The passwords entered do not match')
+            self.add_error('password2', 'The passwords entered do not match')
 
     def save_user(self, *args, **kwargs):
         user = super(UserCreateForm, self).save_user(*args, **kwargs)

--- a/src/apps/ava_core_auth/migrations/0001_initial.py
+++ b/src/apps/ava_core_auth/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 from django.conf import settings

--- a/src/apps/ava_core_auth/models.py
+++ b/src/apps/ava_core_auth/models.py
@@ -13,7 +13,7 @@ class UserRights(models.Model):
     is_admin = models.BooleanField(default=False)
 
     def __unicode__(self):
-        return unicode(self.user)
+        return str(self.user)
 
     @classmethod
     def get(cls, user):

--- a/src/apps/ava_core_group/migrations/0001_initial.py
+++ b/src/apps/ava_core_group/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_group/migrations/0002_auto_20150608_0314.py
+++ b/src/apps/ava_core_group/migrations/0002_auto_20150608_0314.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_group/migrations/0002_auto_20150618_2040.py
+++ b/src/apps/ava_core_group/migrations/0002_auto_20150618_2040.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_group/migrations/0003_merge.py
+++ b/src/apps/ava_core_group/migrations/0003_merge.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_group/models.py
+++ b/src/apps/ava_core_group/models.py
@@ -31,7 +31,7 @@ class Group(TimeStampedModel):
     parent = models.ForeignKey('Group', null=True, blank=True)
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
     def get_absolute_url(self):
         return reverse('group-detail', kwargs={'pk': self.pk})

--- a/src/apps/ava_core_identity/migrations/0001_initial.py
+++ b/src/apps/ava_core_identity/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 import django.core.validators

--- a/src/apps/ava_core_identity/migrations/0002_auto_20150327_1016.py
+++ b/src/apps/ava_core_identity/migrations/0002_auto_20150327_1016.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_identity/migrations/0003_auto_20150402_1354.py
+++ b/src/apps/ava_core_identity/migrations/0003_auto_20150402_1354.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_identity/migrations/0004_auto_20150608_0314.py
+++ b/src/apps/ava_core_identity/migrations/0004_auto_20150608_0314.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_identity/migrations/0004_auto_20150618_2040.py
+++ b/src/apps/ava_core_identity/migrations/0004_auto_20150618_2040.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_identity/migrations/0005_auto_20150619_0303.py
+++ b/src/apps/ava_core_identity/migrations/0005_auto_20150619_0303.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_identity/migrations/0006_merge.py
+++ b/src/apps/ava_core_identity/migrations/0006_merge.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_identity/models.py
+++ b/src/apps/ava_core_identity/models.py
@@ -37,7 +37,7 @@ class Person(TimeStampedModel):
     identity = models.ManyToManyField('Identity', blank=True)
 
     def __unicode__(self):
-        return (self.firstname + " " + self.surname).strip() or u''
+        return (self.firstname + " " + self.surname).strip() or ''
 
     def get_absolute_url(self):
         return reverse('person-detail', kwargs={'pk': self.id})
@@ -75,7 +75,7 @@ class Identifier(TimeStampedModel):
     identity = models.ForeignKey('Identity', related_name='identifiers')
 
     def __unicode__(self):
-        return self.identifier or u''
+        return self.identifier or ''
 
     def get_absolute_url(self):
         return reverse('identifier-detail', kwargs={'pk': self.id})

--- a/src/apps/ava_core_ldap/migrations/0002_auto_20150618_2040.py
+++ b/src/apps/ava_core_ldap/migrations/0002_auto_20150618_2040.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_project/migrations/0001_initial.py
+++ b/src/apps/ava_core_project/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 from django.conf import settings

--- a/src/apps/ava_core_project/migrations/0002_auto_20150324_1627.py
+++ b/src/apps/ava_core_project/migrations/0002_auto_20150324_1627.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 from django.utils import timezone

--- a/src/apps/ava_core_project/migrations/0003_auto_20150608_0314.py
+++ b/src/apps/ava_core_project/migrations/0003_auto_20150608_0314.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_project/migrations/0003_auto_20150618_2040.py
+++ b/src/apps/ava_core_project/migrations/0003_auto_20150618_2040.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_project/migrations/0004_auto_20150617_0125.py
+++ b/src/apps/ava_core_project/migrations/0004_auto_20150617_0125.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_project/migrations/0005_merge.py
+++ b/src/apps/ava_core_project/migrations/0005_merge.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_core_project/models.py
+++ b/src/apps/ava_core_project/models.py
@@ -21,7 +21,7 @@ class Project(TimeStampedModel):
     identifiers = models.ManyToManyField('ava_core_identity.Identifier', null=True, blank=True)
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
     def get_absolute_url(self):
         return reverse('project-detail', kwargs={'pk': self.pk})
@@ -75,7 +75,7 @@ class ProjectTeam(TimeStampedModel):
         return self.team.users.filter(pk=user.id).count() > 0
 
     def __unicode__(self):
-        return unicode(self.project) + u' // ' + unicode(self.team)
+        return str(self.project) + ' // ' + str(self.team)
 
     class Meta:
         unique_together = ('project', 'team')

--- a/src/apps/ava_import_google/models.py
+++ b/src/apps/ava_import_google/models.py
@@ -3,7 +3,7 @@ import ldap, ldif, datetime, re
 from django.db import models
 from django.core.urlresolvers import reverse
 from django.utils.html import escape
-from StringIO import StringIO
+from io import StringIO
 
 from apps.ava_core.models import TimeStampedModel
 from apps.ava_core_identity.models import Identifier, Person, Identity
@@ -77,7 +77,7 @@ class GoogleDirectoryUser(TimeStampedModel):
     google_configuration = models.ForeignKey('GoogleConfiguration')
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
     def get_absolute_url(self):
         return reverse('google-user-detail',kwargs={'pk': self.id})
@@ -117,7 +117,7 @@ class GoogleDirectoryGroup(TimeStampedModel):
     group = models.ForeignKey('ava_core_group.Group', null=True, blank=True)
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
     def get_absolute_url(self):
         return reverse('google-group-detail',kwargs={'pk': self.id})
@@ -133,7 +133,7 @@ class GoogleConfiguration(TimeStampedModel):
     domain = models.CharField(max_length = 100, verbose_name='Primary Domain', unique=True)
 
     def __unicode__(self):
-        return self.domain or u''
+        return self.domain or ''
 
     def get_absolute_url(self):
         return reverse('google-configuration-detail',kwargs={'pk': self.id})
@@ -146,9 +146,9 @@ class GoogleDirectoryHelper():
 
             return google_conn
 
-        except GoogleError, e:
+        except GoogleError as e:
             if type(e.message) == dict:
-                for (k, v) in e.message.iteritems():
+                for (k, v) in e.message.items():
                     sys.stderr.write("%s: %sn" % (k, v))
                     sys.stderr.write("\n")
             else:

--- a/src/apps/ava_import_ldap/ldap_interface.py
+++ b/src/apps/ava_import_ldap/ldap_interface.py
@@ -18,9 +18,9 @@ class ActiveDirectoryHelper:
                                    auto_bind=True)
             return ldap_conn
 
-        except LDAPExceptionError, e:
-            print e.message
-            print e.args
+        except LDAPExceptionError as e:
+            print(e.message)
+            print(e.args)
             sys.exit(1)
 
     def search(self, parameters, filterby, attrs):

--- a/src/apps/ava_import_ldap/migrations/0001_initial.py
+++ b/src/apps/ava_import_ldap/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_import_ldap/migrations/0002_auto_20150608_0314.py
+++ b/src/apps/ava_import_ldap/migrations/0002_auto_20150608_0314.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_import_ldap/models.py
+++ b/src/apps/ava_import_ldap/models.py
@@ -42,7 +42,7 @@ class ActiveDirectoryUser(TimeStampedModel):
     ldap_configuration = models.ForeignKey('LDAPConfiguration')
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
     def get_absolute_url(self):
         return reverse('ad-user-detail', kwargs={'pk': self.id})
@@ -69,7 +69,7 @@ class ActiveDirectoryUser(TimeStampedModel):
         # Check if the data is a Windows FILETIME value.
         match = time_filetime.match(date_value)
         if match:
-            microseconds = long(date_value) / 10
+            microseconds = int(date_value) / 10
             if microseconds > 0:
                 if microseconds > filetime_max:
                     return datetime.datetime.max
@@ -118,7 +118,7 @@ class ActiveDirectoryUser(TimeStampedModel):
             gen_groups = []
             email_addresses = []
 
-            for key, value in attributes.iteritems():
+            for key, value in attributes.items():
                 if len(value) > 0:
                     if key == 'memberOf':
                         for cn in value:
@@ -139,7 +139,7 @@ class ActiveDirectoryUser(TimeStampedModel):
                                 value_string = value_string.decode('utf-8')
                             else:
                                 for e in value:
-                                    if isinstance(e, unicode):
+                                    if isinstance(e, str):
                                         value_string = ''.join(e)
                                     else:
                                         value_string = e['encoded']
@@ -197,12 +197,12 @@ class ActiveDirectoryUser(TimeStampedModel):
                                                  identity=identity)
 
             for group in groups:
-                print groups
+                print(groups)
                 if ad_user.groups.filter(id=group.id).count() == 0:
                     ad_user.groups.add(group)
 
             for gen_group in gen_groups:
-                print gen_group.id
+                print(gen_group.id)
                 if identity.groups.filter(id=gen_group.id).count() == 0:
                     identity.groups.add(gen_group)
 
@@ -219,7 +219,7 @@ class ActiveDirectoryGroup(TimeStampedModel):
     group = models.ForeignKey('ava_core_group.Group', null=True, blank=True)
 
     def __unicode__(self):
-        return self.cn or u''
+        return self.cn or ''
 
     def get_absolute_url(self):
         return reverse('ad-group-detail', kwargs={'pk': self.id})
@@ -242,7 +242,7 @@ class ActiveDirectoryGroup(TimeStampedModel):
         for group in entries:
             attributes = group['attributes']
 
-            for key, value in attributes.iteritems():
+            for key, value in attributes.items():
 
                 if len(value) > 0:
                     value_string = ""
@@ -252,7 +252,7 @@ class ActiveDirectoryGroup(TimeStampedModel):
                             value_string = value_string.decode('utf-8')
                         else:
                             for e in value:
-                                if isinstance(e, unicode):
+                                if isinstance(e, str):
                                     value_string = ''.join(e)
                                     value_string = value_string.decode('utf-8')
                                 else:
@@ -278,15 +278,15 @@ class ActiveDirectoryGroup(TimeStampedModel):
             else:
                 continue
 
-            print attributes['objectGUID']
-            print attributes['objectSid']
-            print attributes['distinguishedName']
+            print(attributes['objectGUID'])
+            print(attributes['objectSid'])
+            print(attributes['distinguishedName'])
 
             # If no matching group currently exists then create one, otherwise
             # update the existing group.
             ad_groups = ActiveDirectoryGroup.objects.filter(**filter_attrs)
             if ad_groups.count() == 0:
-                print "new group"
+                print("new group")
                 ad_group = ActiveDirectoryGroup.objects.create(ldap_configuration=parameters, **attributes)
 
                 gen_group = Group.objects.create(name=ad_group.cn, group_type=Group.AD,
@@ -296,7 +296,7 @@ class ActiveDirectoryGroup(TimeStampedModel):
                 ad_group.group = gen_group
                 ad_group.save()
             else:
-                print "existing group"
+                print("existing group")
                 ad_groups.update(**attributes)
                 ad_group = ad_groups.first()
 
@@ -323,7 +323,7 @@ class LDAPConfiguration(TimeStampedModel):
     server = models.CharField(max_length=100, verbose_name='Server')
 
     def __unicode__(self):
-        return self.server or u''
+        return self.server or ''
 
     class Meta:
         unique_together = ('server', 'user_dn')

--- a/src/apps/ava_import_ldap/urls.py
+++ b/src/apps/ava_import_ldap/urls.py
@@ -36,11 +36,9 @@ urlpatterns = patterns(
         name='ad-group-delete'),
 
     url(r'^(?P<pk>\d+)/import/$', login_required(views.LDAPConfigurationImport.as_view()), name='ldap-import-all'),
-    """
-    url(r'^(?P<pk>\d+)/getusers/$', login_required(views.LDAPConfigurationGetUsers.as_view()), name='ldap-get-users'),
-    url(r'^(?P<pk>\d+)/getgroups/$', login_required(views.LDAPConfigurationGetGroups.as_view()),
-    name='ldap-get-groups'),
-    """
-
-   
+#    """
+#    url(r'^(?P<pk>\d+)/getusers/$', login_required(views.LDAPConfigurationGetUsers.as_view()), name='ldap-get-users'),
+#    url(r'^(?P<pk>\d+)/getgroups/$', login_required(views.LDAPConfigurationGetGroups.as_view()),
+#    name='ldap-get-groups'),
+#    """  
 )

--- a/src/apps/ava_test/helpers.py
+++ b/src/apps/ava_test/helpers.py
@@ -21,6 +21,6 @@ def generate_hex_token(token_chars=32):
 
 
 def generate_tracking_link(url_name, token):
-    root_url = random.choice(settings.PUBLIC_SITE_URLS) or u''
+    root_url = random.choice(settings.PUBLIC_SITE_URLS) or ''
     root_url = root_url.rstrip('/')
     return root_url + reverse(url_name, kwargs={'token': token})

--- a/src/apps/ava_test/migrations/0001_initial.py
+++ b/src/apps/ava_test/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 from django.conf import settings

--- a/src/apps/ava_test/migrations/0002_delete_testresult.py
+++ b/src/apps/ava_test/migrations/0002_delete_testresult.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test/migrations/0003_auto_20150327_1016.py
+++ b/src/apps/ava_test/migrations/0003_auto_20150327_1016.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 from django.conf import settings

--- a/src/apps/ava_test/migrations/0004_auto_20150619_0303.py
+++ b/src/apps/ava_test/migrations/0004_auto_20150619_0303.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test/models.py
+++ b/src/apps/ava_test/models.py
@@ -56,7 +56,7 @@ class Test(ReferenceModel):
     page_template = models.CharField(max_length=100, null=True, blank=True)
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
 
 class TestResult(TimeStampedModel):
@@ -74,4 +74,4 @@ class TestResult(TimeStampedModel):
     via = models.TextField(null=True, blank=True)  # Via
 
     def __unicode__(self):
-        return unicode(self.created)
+        return str(self.created)

--- a/src/apps/ava_test/testrunner.py
+++ b/src/apps/ava_test/testrunner.py
@@ -43,7 +43,7 @@ class TestRunner(object):
             self.set_test_status(Test.RUNNING)
             self.execute_test()
         except Exception as e:
-            print 'Exception: ' + unicode(e)
+            print('Exception: ' + str(e))
             self.set_test_status(Test.ERROR)
             return False
         else:

--- a/src/apps/ava_test_email/migrations/0001_initial.py
+++ b/src/apps/ava_test_email/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 import apps.ava_test.helpers

--- a/src/apps/ava_test_email/migrations/0002_emailtestresult.py
+++ b/src/apps/ava_test_email/migrations/0002_emailtestresult.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_email/migrations/0003_auto_20150617_0225.py
+++ b/src/apps/ava_test_email/migrations/0003_auto_20150617_0225.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_email/migrations/0003_auto_20150618_2040.py
+++ b/src/apps/ava_test_email/migrations/0003_auto_20150618_2040.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_email/migrations/0004_merge.py
+++ b/src/apps/ava_test_email/migrations/0004_merge.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_email/models.py
+++ b/src/apps/ava_test_email/models.py
@@ -14,7 +14,7 @@ class EmailTest(Test):
     is_html = models.BooleanField(null=False, default=False, verbose_name='Send as HTML Email?')
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
     def get_absolute_url(self):
         return reverse('email-test-detail', kwargs={'pk': self.pk})
@@ -29,7 +29,7 @@ class EmailTestTarget(TimeStampedModel):
         unique_together = ("emailtest", "target", "token")
 
     def __unicode__(self):
-        return unicode(self.target)
+        return str(self.target)
 
     def get_absolute_url(self):
         return reverse('email-test-target-detail', kwargs={'pk': self.pk})
@@ -45,7 +45,7 @@ class EmailTemplate(Model):
     message_html = models.TextField(null=True, blank=True)
 
     def __unicode__(self):
-        return self.subject or u''
+        return self.subject or ''
 
     def get_absolute_url(self):
         return reverse('email-template-detail', kwargs={'pk': self.pk})

--- a/src/apps/ava_test_email/tasks.py
+++ b/src/apps/ava_test_email/tasks.py
@@ -44,7 +44,7 @@ class EmailTestSender(TestRunner):
         Gets the list of email targets for the current test.
         """
         targets = self.test.targets.all()
-        print 'Email Targets: [' + ','.join([target.target.identifier for target in targets]) + ']'
+        print('Email Targets: [' + ','.join([target.target.identifier for target in targets]) + ']')
         return targets
 
     def build_email(self, target):

--- a/src/apps/ava_test_tracking/views.py
+++ b/src/apps/ava_test_tracking/views.py
@@ -68,7 +68,7 @@ class RecordTestResultView(generic.TemplateView):
         """
         tracking_info = {'target': target}
         # Fill in as many fields as possible from the request meta information.
-        for field_name, meta_name in self.TRACKING_FIELDS.iteritems():
+        for field_name, meta_name in self.TRACKING_FIELDS.items():
             if meta_name in self.request.META:
                 tracking_info[field_name] = self.request.META[meta_name]
         # Return the tracking info dict.
@@ -91,7 +91,7 @@ class RecordTestResultView(generic.TemplateView):
 
     def get_redirect_url(self, test, kwargs):
         # If the redirect URL is blank or null, there is no URL.
-        redirect_url = (test.redirect_url or u'').strip()
+        redirect_url = (test.redirect_url or '').strip()
         if not redirect_url:
             return None
         # If the redirect URL looks like a JSON object, check for multiple

--- a/src/apps/ava_test_twitter/migrations/0001_initial.py
+++ b/src/apps/ava_test_twitter/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_twitter/migrations/0002_twittertestresult.py
+++ b/src/apps/ava_test_twitter/migrations/0002_twittertestresult.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_twitter/migrations/0003_auto_20150327_1016.py
+++ b/src/apps/ava_test_twitter/migrations/0003_auto_20150327_1016.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_twitter/migrations/0004_auto_20150617_0208.py
+++ b/src/apps/ava_test_twitter/migrations/0004_auto_20150617_0208.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_twitter/migrations/0005_auto_20150619_0303.py
+++ b/src/apps/ava_test_twitter/migrations/0005_auto_20150619_0303.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/src/apps/ava_test_twitter/models.py
+++ b/src/apps/ava_test_twitter/models.py
@@ -13,7 +13,7 @@ class TwitterTest(Test):
     twitteraccount = models.ForeignKey('TwitterAccount', null=False, verbose_name='Send From Twitter Account')
 
     def __unicode__(self):
-        return self.name or u''
+        return self.name or ''
 
     def get_absolute_url(self):
         return reverse('twitter-test-detail', kwargs={'pk': self.pk})
@@ -27,7 +27,7 @@ class TwitterTestTarget(TimeStampedModel):
         unique_together = ("twittertest", "target")
 
     def __unicode__(self):
-        return self.target or u''
+        return self.target or ''
 
 
 class TwitterTestResult(TestResult):

--- a/src/settings.py
+++ b/src/settings.py
@@ -181,8 +181,9 @@ except ImportError:
 ## HAYSTACK CONFIGURATION
 HAYSTACK_CONNECTIONS = {
     'default': {
-        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
-        'PATH': os.path.join(os.path.dirname(__file__), 'whoosh_index'),
+        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+        'URL': 'http://127.0.0.1:9200/',
+        'INDEX_NAME': 'haystack',
     },
 }
 

--- a/src/urls.py
+++ b/src/urls.py
@@ -9,7 +9,8 @@ admin.autodiscover()
 handler404 = 'dh5bp.views.page_not_found'
 handler500 = 'dh5bp.views.server_error'
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     url(r'^$', login_required(DashboardView.as_view()), name='index'),
     url(r'^ava/', include('apps.ava_core.urls')),
     url(r'^project/', include('apps.ava_core_project.urls')),


### PR DESCRIPTION
The bulk of the Python 3.4 migration is functional and working. There may be additional breakage that we will uncover through testing.