### PR TITLE
Add the Django Debug Toolbar

### DIFF
--- a/ava/settings/base.py
+++ b/ava/settings/base.py
@@ -104,6 +104,7 @@ THIRD_PARTY_APPS = (
     'd3',
     'djrill',
     'twython',
+    'debug_toolbar',
 )
 
 INSTALLED_APPS = DEFAULT_APPS + THIRD_PARTY_APPS + LOCAL_APPS
@@ -285,3 +286,11 @@ CSP_IMG_SRC = (
 ## GOOGLE OAUTH2 CONFIGURATION
 GOOGLE_OAUTH2_CLIENT_ID = os.environ.get('GOOGLE_OAUTH2_CLIENT_ID', None)
 GOOGLE_OAUTH2_CLIENT_SECRET = os.environ.get('GOOGLE_OAUTH2_CLIENT_SECRET', None)
+
+
+# DJANGO DEBUG TOOLBAR CONFIGURATION
+def _show_toolbar_callback(request):
+    return DEBUG
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': _show_toolbar_callback,
+}

--- a/ava/settings/base.py
+++ b/ava/settings/base.py
@@ -290,7 +290,9 @@ GOOGLE_OAUTH2_CLIENT_SECRET = os.environ.get('GOOGLE_OAUTH2_CLIENT_SECRET', None
 
 # DJANGO DEBUG TOOLBAR CONFIGURATION
 def _show_toolbar_callback(request):
-    return DEBUG
+    toolbar_is_enabled = os.environ.get('DISABLE_DJANGO_DEBUG_TOOLBAR', 'false').lower() != 'true'
+    return DEBUG and toolbar_is_enabled
+
 DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': _show_toolbar_callback,
 }

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,3 +25,4 @@ flake8
 oauth2client
 google-api-python-client
 
+django-debug-toolbar

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,0 +1,15 @@
+# A file called 'secrets.env' can be used to add extra variables to
+# your development environment.
+#
+# If you need to tailor some of these settings, copy this file
+# from 'secrets.env.example' to 'secrets.env'.
+#
+# Please never commit your copy of secret.env to a repository.
+
+# Set this variable to 'true' if you want to disable the Django Debug Toolbar.
+DISABLE_DJANGO_DEBUG_TOOLBAR=false
+
+# Set these two variables if you are testing the google apps integration.
+GOOGLE_OAUTH2_CLIENT_ID=
+GOOGLE_OAUTH2_CLIENT_SECRET=
+


### PR DESCRIPTION
I've always had a bit of mixed feelings for the Django Debug Toolbar, I always *want* to love it but I often end up disabling it when it gets in the way.

This PR sets it up and configures it, and we can use it for a while and decide whether it's useful. A couple of the features are disabled due to the CSP clobbering it a little, but most of it is there and working.