### PR TITLE
Move container-scripts into their own subdirectory. Add autotest.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.4
-RUN apt-get update -qq && apt-get install -y build-essential python3-dev libpqxx-4.0 libpqxx-dev libldap2-dev libsasl2-dev libssl-dev
+RUN apt-get update -qq && apt-get install -y build-essential python3-dev libpqxx-4.0 libpqxx-dev libldap2-dev libsasl2-dev libssl-dev inotify-tools
 RUN mkdir /code
 WORKDIR /code
 ADD . /code/

--- a/bin/auto-test.sh
+++ b/bin/auto-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+## The secret to test-driven development that actually works is
+## to reduce the barriers of running the test-suite to zero.
+
+## Running this script:
+##
+## - Sets up a docker container that listens for any file changes
+##   in the ava/ directory.
+## - Whenever a file changes, it runs the test suite.
+## - Loop forever.
+##
+## Unfortunately, a quick google implies that this won't work
+## effectively for boot2docker setups. We'll have to work out
+## another solution to make that happen.
+
+cd $(dirname $0)/..
+docker-compose run web ./bin/in-container/auto-test.sh

--- a/bin/in-container/README
+++ b/bin/in-container/README
@@ -1,0 +1,4 @@
+
+Scripts in this directory are expecting to be run from WITHIN the
+context of the AVA container.
+

--- a/bin/in-container/auto-test.sh
+++ b/bin/in-container/auto-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+EXCLUDE='\.git|\.tmp|\~|\#'
+
+cd $(dirname $0)/../..
+
+clear
+
+while true;
+do
+    echo
+    echo "Listening for file changes, hit CTRL-C a couple times in a row to exit."
+    echo
+    inotifywait -qr -e CLOSE_WRITE -e CREATE -e MODIFY --exclude ${EXCLUDE} ava/
+    ## Sleep briefly, during which time CTRL-C will actually exit the script.
+    sleep 2 || exit 1
+    clear
+    ## Run the test suit, passing in any further arguments wanted.
+    ./manage.py test "$@"
+done

--- a/bin/in-container/run-celery-worker.sh
+++ b/bin/in-container/run-celery-worker.sh
@@ -5,7 +5,7 @@
 ## ensure the database is built, and then executes the internal
 ## Django devserver.
 
-DIRECTORY=$(dirname $0)/..
+DIRECTORY=$(dirname $0)/../..
 PYTHON=python
 MANAGE=${DIRECTORY}/manage.py
 

--- a/bin/in-container/run-devserver.sh
+++ b/bin/in-container/run-devserver.sh
@@ -10,7 +10,7 @@
 ## A TODO is to either configure this script to run in a non-debug
 ## "production" mode, or a separate script.
 
-DIRECTORY=$(dirname $0)/..
+DIRECTORY=$(dirname $0)/../..
 PYTHON=python
 MANAGE=${DIRECTORY}/manage.py
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ elasticsearch:
 ## AVA Application Server
 web:
   build: .
-  command: bin/run-devserver.sh
+  command: bin/in-container/run-devserver.sh
   volumes:
     - .:/code
   ports:
@@ -40,7 +40,7 @@ web:
 ## AVA Asynchronous Task Worker
 worker:
   build: .
-  command: bin/run-celery-worker.sh
+  command: bin/in-container/run-celery-worker.sh
   volumes:
     - .:/code
   links:


### PR DESCRIPTION
 - bin/autotest.sh is a script that automatically runs the test suite
   when a file change is detected, at the moment it doesn't work with
   build2docker :-(