### PR TITLE
unicode to str

### DIFF
--- a/ava/core/models.py
+++ b/ava/core/models.py
@@ -19,7 +19,7 @@ class ReferenceModel(TimeStampedModel):
     name = models.CharField(max_length=100, verbose_name='Name')
     description = models.TextField(max_length=500, verbose_name='Description')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or ''
 
     class Meta:

--- a/ava/core_auth/models.py
+++ b/ava/core_auth/models.py
@@ -13,7 +13,7 @@ class UserRights(models.Model):
     user = models.OneToOneField(User, related_name='rights')
     is_admin = models.BooleanField(default=False)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.user)
 
     @classmethod

--- a/ava/core_group/models.py
+++ b/ava/core_group/models.py
@@ -30,7 +30,7 @@ class Group(TimeStampedModel):
     group_type = models.CharField(max_length=20, choices=GROUP_TYPE_CHOICES, default=GENERIC, verbose_name='Group Type')
     parent = models.ForeignKey('Group', null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or ''
 
     def get_absolute_url(self):

--- a/ava/core_identity/models.py
+++ b/ava/core_identity/models.py
@@ -37,7 +37,7 @@ class Person(TimeStampedModel):
     surname = models.CharField(max_length=75, validators=[validate_slug])
     identity = models.ManyToManyField('Identity', blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return (self.first_name + " " + self.surname).strip() or ''
 
     def get_absolute_url(self):
@@ -76,7 +76,7 @@ class Identifier(TimeStampedModel):
                                        verbose_name='Identifier Type')
     identity = models.ForeignKey('Identity', related_name='identifiers')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.identifier or ''
 
     def get_absolute_url(self):

--- a/ava/import_google/models.py
+++ b/ava/import_google/models.py
@@ -47,7 +47,7 @@ class GoogleDirectoryUser(TimeStampedModel):
     groups = models.ManyToManyField('GoogleDirectoryGroup', related_name='users')
     google_configuration = models.ForeignKey('GoogleConfiguration')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or ''
 
     def get_absolute_url(self):
@@ -70,7 +70,7 @@ class GoogleDirectoryGroup(TimeStampedModel):
     google_configuration = models.ForeignKey('GoogleConfiguration')
     group = models.ForeignKey('core_group.Group', null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or ''
 
     def get_absolute_url(self):
@@ -86,7 +86,7 @@ class GoogleDirectoryGroup(TimeStampedModel):
 class GoogleConfiguration(TimeStampedModel):
     domain = models.CharField(max_length=100, verbose_name='Primary Domain', unique=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.domain or ''
 
     def get_absolute_url(self):

--- a/ava/import_ldap/models.py
+++ b/ava/import_ldap/models.py
@@ -42,7 +42,7 @@ class ActiveDirectoryUser(TimeStampedModel):
     groups = models.ManyToManyField('ActiveDirectoryGroup', related_name='users')
     ldap_configuration = models.ForeignKey('LDAPConfiguration')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or ''
 
     def get_absolute_url(self):
@@ -254,7 +254,7 @@ class ActiveDirectoryGroup(TimeStampedModel):
     ldap_configuration = models.ForeignKey('LDAPConfiguration')
     group = models.ForeignKey('core_group.Group', null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.cn or ''
 
     def get_absolute_url(self):
@@ -371,7 +371,7 @@ class LDAPConfiguration(TimeStampedModel):
     dump_dn = models.CharField(max_length=100, verbose_name='Domain')
     server = models.CharField(max_length=100, verbose_name='Server')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.server or ''
 
     class Meta:

--- a/ava/test/models.py
+++ b/ava/test/models.py
@@ -55,7 +55,7 @@ class Test(ReferenceModel):
     # if a redirect URL is specified.
     page_template = models.CharField(max_length=100, null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or ''
 
 
@@ -74,5 +74,5 @@ class TestResult(TimeStampedModel):
     referrer = models.TextField(null=True, blank=True)  # Referer
     via = models.TextField(null=True, blank=True)  # Via
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.created)

--- a/ava/test_email/models.py
+++ b/ava/test_email/models.py
@@ -13,7 +13,7 @@ class EmailTest(Test):
     body = models.TextField(null=False, verbose_name='Message Body')
     is_html = models.BooleanField(null=False, default=False, verbose_name='Send as HTML Email?')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or ''
 
     def get_absolute_url(self):
@@ -28,7 +28,7 @@ class EmailTestTarget(TimeStampedModel):
     class Meta:
         unique_together = ("emailtest", "target", "token")
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.target)
 
     def get_absolute_url(self):
@@ -44,7 +44,7 @@ class EmailTemplate(Model):
     message = models.TextField(null=False)
     message_html = models.TextField(null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.subject or ''
 
     def get_absolute_url(self):

--- a/ava/test_twitter/models.py
+++ b/ava/test_twitter/models.py
@@ -11,7 +11,7 @@ class TwitterTest(Test):
     link = models.ForeignKey('TweetLink', null=False)
     twitter_account = models.ForeignKey('TwitterAccount', null=False, verbose_name='Send From Twitter Account')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or ''
 
     def get_absolute_url(self):
@@ -25,7 +25,7 @@ class TwitterTestTarget(TimeStampedModel):
     class Meta:
         unique_together = ("twitter_test", "target")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.target or ''
 
 


### PR DESCRIPTION
Replaced references to __unicode__ with __str__. This was required as
part of the transition to python 3