### PR TITLE
Remove LDAP credential storage from the database.

### DIFF
--- a/ava/import_ldap/forms.py
+++ b/ava/import_ldap/forms.py
@@ -1,13 +1,79 @@
+import logging
+
 import django.forms
+from django.db import transaction
 
 from ava.import_ldap.models import LDAPConfiguration
+
+
+log = logging.getLogger(__name__)
 
 
 class LDAPConfigurationForm(django.forms.ModelForm):
 
     class Meta:
         model = LDAPConfiguration
-        fields = ('user_dn', 'user_pw', 'dump_dn', 'server')
+        fields = ('dump_dn', 'server')
+
+
+class LDAPConfigurationCredentialsForm(LDAPConfigurationForm):
+    user_dn = django.forms.CharField(max_length=100, help_text='User (not saved)')
+    user_pw = django.forms.CharField(max_length=100, help_text='Password (not saved)')
+
+    class Meta(LDAPConfigurationForm.Meta):
         widgets = {
             'user_pw': django.forms.PasswordInput(),
         }
+
+    def run_ldap_import(self):
+        """Run the LDAP Import using the form.
+
+        We wrap the operation in a transaction, and run the import. If
+        the import fails, we roll back the transaction and insert an
+        error into the form's error list, the view can then return the
+        form_invalid response.
+
+        Before you ask: Yeah, this is weird.
+
+        But it saves us a lot of trouble with error-handling during
+        the import:
+
+        - We get bounced back to the LDAP wizard step, with a useful
+          error message.
+
+        - The LDAP configuration is not saved to the database, so
+          we're not left in an inconsistent state, the user can
+          simply try again.
+
+        Returns 'True' if the import appeared to succeed, and 'False'
+        if something went wrong (while also inserting an error into
+        the form object.
+
+        """
+        try:
+            # enter the transaction.
+            with transaction.atomic():
+                # save the form.
+                self.save()
+                # run the LDAP import
+                self.instance.import_all(
+                    user_dn=self.cleaned_data['user_dn'],
+                    user_pw=self.cleaned_data['user_dn'],
+                )
+            # At the moment 'no exception being thrown' is the best
+            # measure for success we have, so if we got here, it
+            # must have worked.
+            return True
+
+        except Exception as e:
+            # Something went wrong, the transaction has already rolled
+            # back. We log the exception, insert an error into the
+            # form's errorlist, and trigger the 'invalid_form' view
+            # path to return the customer to the LDAP configuration
+            # screen.
+            log.exception("Error during LDAP import.", exc_info=e)
+            self.add_error(
+                field=None,
+                error="Sorry, an error occurred during LDAP import. See the debug log for details"
+            )
+            return False

--- a/ava/import_ldap/migrations/0003_auto_20150713_2333.py
+++ b/ava/import_ldap/migrations/0003_auto_20150713_2333.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('import_ldap', '0002_auto_20150710_0019'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='ldapconfiguration',
+            unique_together=set([]),
+        ),
+        migrations.RemoveField(
+            model_name='ldapconfiguration',
+            name='user_dn',
+        ),
+        migrations.RemoveField(
+            model_name='ldapconfiguration',
+            name='user_pw',
+        ),
+    ]

--- a/ava/import_ldap/migrations/0004_auto_20150717_0435.py
+++ b/ava/import_ldap/migrations/0004_auto_20150717_0435.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('import_ldap', '0003_auto_20150713_2333'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='ldapconfiguration',
+            unique_together=set([('server', 'dump_dn')]),
+        ),
+    ]

--- a/ava/import_ldap/models.py
+++ b/ava/import_ldap/models.py
@@ -359,15 +359,10 @@ class ActiveDirectoryGroup(TimeStampedModel):
 
 
 class LDAPConfiguration(TimeStampedModel):
-
     """
-    user_dn = "cn=Administrator,cn=Users,dc=ava,dc=test,dc=domain"
-    user_pw = "Password1"
     dump_dn = "dc=ava,dc=test,dc=domain"
     server = 'ldap://dc.ava.test.domain'
     """
-    user_dn = models.CharField(max_length=100, verbose_name='User')
-    user_pw = models.CharField(max_length=100, verbose_name='Password')
     dump_dn = models.CharField(max_length=100, verbose_name='Domain')
     server = models.CharField(max_length=100, verbose_name='Server')
 
@@ -375,12 +370,12 @@ class LDAPConfiguration(TimeStampedModel):
         return self.server or ''
 
     class Meta:
-        unique_together = ('server', 'user_dn')
+        unique_together = ('server', 'dump_dn')
 
     def get_absolute_url(self):
         return reverse('ldap-configuration-detail', kwargs={'pk': self.id})
 
-    def import_all(self):
+    def import_all(self, user_dn, user_pw):
         ad_group = ActiveDirectoryGroup()
         ad_group.get_groups(self)
         ad_user = ActiveDirectoryUser()

--- a/ava/import_ldap/urls.py
+++ b/ava/import_ldap/urls.py
@@ -15,6 +15,9 @@ urlpatterns = patterns(
         name='ldap-configuration-update'),
     url(r'^(?P<pk>\d+)/delete/$', login_required(views.LDAPConfigurationDelete.as_view()),
         name='ldap-configuration-delete'),
+    url(r'^(?P<pk>\d+)/import/$', login_required(views.LDAPConfigurationImport.as_view()),
+        name='ldap-import-all'),
+
 
     url(r'^(?P<pk>\d+)/aduser/$', login_required(views.ActiveDirectoryUserIndex.as_view()), name='ad-user-index'),
     url(r'^(?P<pk>\d+)/aduser/new/$', login_required(views.ActiveDirectoryUserCreate.as_view()), name='ad-user-create'),
@@ -35,7 +38,6 @@ urlpatterns = patterns(
     url(r'^adgroup/(?P<pk>\d+)/delete/$', login_required(views.ActiveDirectoryGroupDelete.as_view()),
         name='ad-group-delete'),
 
-    url(r'^(?P<pk>\d+)/import/$', login_required(views.LDAPConfigurationImport.as_view()), name='ldap-import-all'),
     #    """
     #    url(r'^(?P<pk>\d+)/getusers/$', login_required(views.LDAPConfigurationGetUsers.as_view()), name='ldap-get-users'),
     #    url(r'^(?P<pk>\d+)/getgroups/$', login_required(views.LDAPConfigurationGetGroups.as_view()),

--- a/templates/ldap/LDAPConfiguration_detail.html
+++ b/templates/ldap/LDAPConfiguration_detail.html
@@ -20,14 +20,6 @@
                             <td>Dump DN:</td>
                             <td>{{ ldap_configuration.dump_dn }}</td>
                         </tr>
-                         <tr>
-                            <td>User:</td>
-                            <td>{{ ldap_configuration.user_dn }}</td>
-                        </tr>
-                         <tr>
-                            <td>Password:</td>
-                            <td>{{ ldap_configuration.user_pw}}</td>
-                        </tr>
                         </tbody>
                     </table>
                     <div class="button pull-left">

--- a/templates/ldap/LDAPConfiguration_import.html
+++ b/templates/ldap/LDAPConfiguration_import.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% load bootstrap %}
+{% load staticfiles %}
+
+{% block mainpage %}
+
+<div class="page-header">
+  <h1>Import from LDAP Server</h1>
+</div>
+
+<p>Please add your login credentials to begin the import. AVA does not save your credentials.</p>
+
+        <form action="." method="post">
+            {% csrf_token %}
+	    {{ form|bootstrap }}
+
+	    <div class="form-actions button pull-right">
+	      <button type="submit" class="btn btn-success btn-md">Import from LDAP</button>
+	    </div>
+</form>
+
+{% endblock %}


### PR DESCRIPTION
 - LDAPConfiguration objects now just include 'server' and 'dump_dn'.
 - The model form has a subclass that includes the credentials for the
   view that requires them.
 - The Welcome app is updated to create and run the first import.
 - Updated the CRUD views in '/ldap/'