### PR TITLE
Disable the Django Debug Toolbar by default.

### DIFF
--- a/ava/settings/base.py
+++ b/ava/settings/base.py
@@ -309,7 +309,7 @@ GOOGLE_OAUTH2_REDIRECT_URL = os.environ.get(
 
 # DJANGO DEBUG TOOLBAR CONFIGURATION
 def _show_toolbar_callback(request):
-    toolbar_is_enabled = os.environ.get('DISABLE_DJANGO_DEBUG_TOOLBAR', 'false').lower() != 'true'
+    toolbar_is_enabled = os.environ.get('ENABLE_DJANGO_DEBUG_TOOLBAR', 'false').lower() == 'true'
     return DEBUG and toolbar_is_enabled
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -6,8 +6,8 @@
 #
 # Please never commit your copy of secret.env to a repository.
 
-# Set this variable to 'true' if you want to disable the Django Debug Toolbar.
-DISABLE_DJANGO_DEBUG_TOOLBAR=false
+# Set this variable to 'true' if you want to enable the Django Debug Toolbar.
+ENABLE_DJANGO_DEBUG_TOOLBAR=false
 
 # Set these three variables if you are testing the google apps integration.
 GOOGLE_OAUTH2_CLIENT_ID=


### PR DESCRIPTION
This patch swaps the default behaviour and the
configuration environment variable for enabling
the Django Debug Toolbar so that you have to have
it enabled explicitly if you want to use it.