### PR TITLE
Add a placeholder secrets.env

### DIFF
--- a/secrets.env
+++ b/secrets.env
@@ -1,0 +1,9 @@
+#
+# Please replace this file with secrets.env.example and then
+# update it as necessary:
+#
+# e.g. 'cp secrets.env.example secrets.env'
+#
+# Do not commit changes to this file to the git repository!
+#
+


### PR DESCRIPTION
I didn't realize docker-compose failed if secrets.env was missing.
So I've added a placeholder with no variables to prevent this from
being a stumbling block to new developers.

The 'secrets.env' file will remain listed in '.gitignore' so that
updates to the file won't be accidentally commited to the repository.