### PR TITLE
Add toggle for DEBUG mode, override default 404/500 templates.

### DIFF
--- a/ava/settings/base.py
+++ b/ava/settings/base.py
@@ -14,8 +14,26 @@ BASE_DIR = os.path.abspath(
     )
 )
 
-DEBUG = True
-TEMPLATE_DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'true').lower() == 'true'
+TEMPLATE_DEBUG = DEBUG
+
+# The ALLOWED_HOSTS setting is a security setting. It should be set
+# with the host names that the application is expecting to receive
+# requests as. For example 'localhost' and 'avasecure.com'.
+#
+# It's not checked unless DEBUG is turned off, and so we're using
+# the liberal default of '*', this isn't appropriate for a production
+# deployment.
+#
+# You can set custom hostnames using the DJANGO_ALLOWED_HOSTS environment
+# variable in secrets.env
+#
+# See the link to the Django documentation for more details.
+#
+# https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts
+DEFAULT_ALLOWED_HOSTS = '*'
+ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS',
+                               DEFAULT_ALLOWED_HOSTS).strip().split()
 
 TEMPLATES = [
     {

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -6,6 +6,10 @@
 #
 # Please never commit your copy of secret.env to a repository.
 
+# set this value to 'false' turn off Django's 'DEBUG' mode. For now while
+# AVA is in development, it defaults to 'true'
+DJANGO_DEBUG=false
+
 # Set this variable to 'true' if you want to enable the Django Debug Toolbar.
 ENABLE_DJANGO_DEBUG_TOOLBAR=false
 
@@ -14,3 +18,9 @@ GOOGLE_OAUTH2_CLIENT_ID=
 GOOGLE_OAUTH2_CLIENT_SECRET=
 GOOGLE_OAUTH2_REDIRECT_URL=http://<YOUR_DOMAIN:PORT>/google_auth/oauth2callback/
 
+## If you're deploying a non-DEBUG/dev version of AVA, you can use this setting
+## to configure the ALLOWED_HOSTS django setting. Refer to settings/base.py and
+## the documentation for more details.
+##
+## https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts
+# DJANGO_ALLOWED_HOSTS=localhost avasecure.com

--- a/templates/dh5bp/404.html
+++ b/templates/dh5bp/404.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>AVA: Page Not Found</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+
+            * {
+                margin: 0;
+                line-height: 1.5;
+            }
+
+            html {
+                color: #888;
+                font-family: sans-serif;
+                text-align: center;
+            }
+
+            body {
+                left: 50%;
+                margin: -43px 0 0 -150px;
+                position: absolute;
+                top: 50%;
+                width: 300px;
+            }
+
+            h1 {
+                color: #555;
+                font-size: 2em;
+                font-weight: 400;
+            }
+
+            p {
+                line-height: 1.2;
+            }
+
+            @media only screen and (max-width: 270px) {
+
+                body {
+                    margin: 10px auto;
+                    position: static;
+                    width: 95%;
+                }
+
+                h1 {
+                    font-size: 1.5em;
+                }
+
+            }
+
+        </style>
+    </head>
+    <body>
+        <h1>Page Not Found</h1>
+        <p>Sorry, but the page you were trying to view does not exist.</p>
+    </body>
+</html>
+<!-- IE requires 512+ bytes: http://www.404-error-page.com/404-error-page-too-short-problem-microsoft-ie.shtml -->

--- a/templates/dh5bp/500.html
+++ b/templates/dh5bp/500.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>AVA: Internal Error</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+
+            * {
+                margin: 0;
+                line-height: 1.5;
+            }
+
+            html {
+                color: #888;
+                font-family: sans-serif;
+                text-align: center;
+            }
+
+            body {
+                left: 50%;
+                margin: -43px 0 0 -150px;
+                position: absolute;
+                top: 50%;
+                width: 300px;
+            }
+
+            h1 {
+                color: #555;
+                font-size: 2em;
+                font-weight: 400;
+            }
+
+            p {
+                line-height: 1.2;
+            }
+
+            @media only screen and (max-width: 270px) {
+
+                body {
+                    margin: 10px auto;
+                    position: static;
+                    width: 95%;
+                }
+
+                h1 {
+                    font-size: 1.5em;
+                }
+
+            }
+
+        </style>
+    </head>
+    <body>
+        <h1>Internal Error</h1>
+<p>We are sorry for the inconvenience, but something went wrong.</p><p>We have logged the problem and will be investigating soon.</p><p>Please go back and try again.</p>
+        
+    </body>
+</html>
+<!-- IE requires 512+ bytes: http://www.404-error-page.com/404-error-page-too-short-problem-microsoft-ie.shtml -->


### PR DESCRIPTION
 - Add an environment variable to secrets.env allowing you to
   disable the DJANGO debug mode.
 - Add a variable for handing the ALLOWED_HOSTS parameter to
   secrets.env in case you need to configure it when DEBUG is
   turned off.
 - Copy the default dh5bp 404/500 templates into the ava/templates
   directory so that they can be easily customised.